### PR TITLE
modify conditions for texture

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: soilptf
 Type: Package
 Title: Estimate soil properties via pedotransferfunctions
-Version: 0.2.0
+Version: 0.2.1
 Authors@R: c(person(given = "Gerard", family = "Ros", email = "gerard.ros@nmi-agro.nl", role = c("aut","cre")),
              person(given = "Kees", family = "van den Dool", email = "kees.vandendool@nmi-agro.nl", role = c("aut")),
              person(given = "Sven", family = "Verweij", email = "sven.verweij@nmi-agro.nl", role = c("aut")),

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,10 @@
 # Changelog soilptf
 
+## Version 0.2.1 2023-04-24
+### Fixed
+* summing and rounding error in when checking that `A_SILT_MI`, `A_CLAY_MI`, and 
+`A_SAND_MI` never exceed 100 resolving #18
+
 ## Version 0.2.0  2023-04-14
 
 ### Added

--- a/R/bulkdensity.R
+++ b/R/bulkdensity.R
@@ -5037,6 +5037,7 @@ sptf_bd140 <- function(A_SOM_LOI, A_CLAY_MI, A_SAND_MI,A_SILT_MI) {
   check_numeric('A_CLAY_MI', A_CLAY_MI, FALSE, arg.length)
   check_numeric('A_SAND_MI', A_SAND_MI, FALSE, arg.length)
   check_numeric('A_SILT_MI', A_SILT_MI, FALSE, arg.length)
+  checkmate::assert_true(all(round(rowSums(data.table(A_CLAY_MI, A_SAND_MI, A_SILT_MI)),3) <= 100))
   
   # Collect data into a table (set in units %)
   dt <- data.table(A_SOM_LOI = A_SOM_LOI, 

--- a/R/bulkdensity.R
+++ b/R/bulkdensity.R
@@ -5114,7 +5114,7 @@ sptf_bd142 <- function(A_CLAY_MI, A_SAND_MI,A_SILT_MI) {
   check_numeric('A_CLAY_MI', A_CLAY_MI, FALSE, arg.length)
   check_numeric('A_SAND_MI', A_SAND_MI, FALSE, arg.length)
   check_numeric('A_SILT_MI', A_SILT_MI, FALSE, arg.length)
-  checkmate::assert_true(all(rowSums(data.table(A_CLAY_MI, A_SAND_MI, A_SILT_MI)) <= 100))
+  checkmate::assert_true(all(round(rowSums(data.table(A_CLAY_MI, A_SAND_MI, A_SILT_MI)),3) <= 100))
   
   # Collect data into a table (set SOC in units %)
   dt <- data.table(A_CLAY_MI = A_CLAY_MI,
@@ -5153,7 +5153,7 @@ sptf_bd143 <- function(A_C_OF, A_CLAY_MI, A_SAND_MI,A_SILT_MI) {
   check_numeric('A_CLAY_MI', A_CLAY_MI, FALSE, arg.length)
   check_numeric('A_SAND_MI', A_SAND_MI, FALSE, arg.length)
   check_numeric('A_SILT_MI', A_SILT_MI, FALSE, arg.length)
-  checkmate::assert_true(all(rowSums(data.table(A_CLAY_MI, A_SAND_MI, A_SILT_MI)) <= 100))
+  checkmate::assert_true(all(round(rowSums(data.table(A_CLAY_MI, A_SAND_MI, A_SILT_MI)),3) <= 100))
   
   # Collect data into a table (set SOC in units %)
   dt <- data.table(A_C_OF = A_C_OF * 0.1, 
@@ -5195,7 +5195,7 @@ sptf_bd144 <- function(A_C_OF, A_CLAY_MI, A_SAND_MI) {
   check_numeric('A_C_OF', A_C_OF, FALSE, arg.length)
   check_numeric('A_CLAY_MI', A_CLAY_MI, FALSE, arg.length)
   check_numeric('A_SAND_MI', A_SAND_MI, FALSE, arg.length)
-  checkmate::assert_true(sum(A_CLAY_MI, A_SAND_MI) <= 100)
+  checkmate::assert_true(all(round(rowSums(data.table(A_CLAY_MI, A_SAND_MI)),3) <= 100))
   
   # Collect data into a table (set units in g/kg)
   dt <- data.table(A_C_OF = A_C_OF * 0.1, 
@@ -5239,7 +5239,7 @@ sptf_bd145 <- function(A_C_OF, A_CLAY_MI, A_SAND_MI,A_SILT_MI) {
   check_numeric('A_CLAY_MI', A_CLAY_MI, FALSE, arg.length)
   check_numeric('A_SAND_MI', A_SAND_MI, FALSE, arg.length)
   check_numeric('A_SILT_MI', A_SILT_MI, FALSE, arg.length)
-  checkmate::assert_true(all(rowSums(data.table(A_CLAY_MI, A_SAND_MI, A_SILT_MI)) <= 100))
+  checkmate::assert_true(all(round(rowSums(data.table(A_CLAY_MI, A_SAND_MI, A_SILT_MI)),3) <= 100))
   
   # Collect data into a table (set units in g/kg)
   dt <- data.table(A_C_OF = A_C_OF * 0.1, 
@@ -5329,7 +5329,7 @@ sptf_bd147 <- function(A_C_OF, A_CLAY_MI, A_SAND_MI,A_SILT_MI, A_DEPTH) {
   check_numeric('A_SAND_MI', A_SAND_MI, FALSE, arg.length)
   check_numeric('A_SILT_MI', A_SILT_MI, FALSE, arg.length)
   check_numeric('A_DEPTH', A_DEPTH, FALSE, arg.length)
-  checkmate::assert_true(all(rowSums(data.table(A_CLAY_MI, A_SAND_MI, A_SILT_MI)) <= 100))
+  checkmate::assert_true(all(round(rowSums(data.table(A_CLAY_MI, A_SAND_MI, A_SILT_MI)),3) <= 100))
   
   # Collect data into a table (set units in g/100 g, depth in cm)
   # silt should be coarse silt
@@ -5488,7 +5488,7 @@ sptf_bd151 <- function(A_CLAY_MI, A_SAND_MI, A_SILT_MI) {
   check_numeric('A_CLAY_MI', A_CLAY_MI, FALSE, arg.length)
   check_numeric('A_SAND_MI', A_SAND_MI, FALSE, arg.length)
   check_numeric('A_SILT_MI', A_SILT_MI, FALSE, arg.length)
-  checkmate::assert_true(all(rowSums(data.table(A_CLAY_MI, A_SAND_MI, A_SILT_MI)) <= 100))
+  checkmate::assert_true(all(round(rowSums(data.table(A_CLAY_MI, A_SAND_MI, A_SILT_MI)),3) <= 100))
   
   # Collect data into a table (set in units %)
   dt <- data.table(A_CLAY_MI = A_CLAY_MI,
@@ -5700,7 +5700,7 @@ sptf_bd157 <- function(A_C_OF, A_CLAY_MI, A_SILT_MI) {
   check_numeric('A_C_OF', A_C_OF, FALSE, arg.length)
   check_numeric('A_CLAY_MI', A_CLAY_MI, FALSE, arg.length)
   check_numeric('A_SILT_MI', A_SILT_MI, FALSE, arg.length)
-  checkmate::assert_true(sum(A_CLAY_MI, A_SILT_MI) <= 100)
+  checkmate::assert_true(all(round(rowSums(data.table(A_CLAY_MI, A_SILT_MI)),3) <= 100))
   
   # Collect data into a table (set in units %)
   dt <- data.table(A_C_OF = A_C_OF * 0.1, 
@@ -5961,7 +5961,7 @@ sptf_bd164 <- function(A_SOM_LOI, A_CLAY_MI, A_SAND_MI, A_SILT_MI) {
   check_numeric('A_CLAY_MI', A_CLAY_MI, FALSE, arg.length)
   check_numeric('A_SAND_MI', A_SAND_MI, FALSE, arg.length)
   check_numeric('A_SILT_MI', A_SILT_MI, FALSE, arg.length)
-  checkmate::assert_true(all(rowSums(data.table(A_CLAY_MI, A_SAND_MI, A_SILT_MI)) <= 100))
+  checkmate::assert_true(all(round(rowSums(data.table(A_CLAY_MI, A_SAND_MI, A_SILT_MI)),3) <= 100))
   
   # Collect data into a table (set in units %)
   dt <- data.table(A_SOM_LOI = A_SOM_LOI, 

--- a/tests/testthat/test-sptf-bulkdensity.R
+++ b/tests/testthat/test-sptf-bulkdensity.R
@@ -1324,3 +1324,38 @@ test_that("Bulk density functions returns the correct values", {
   
 })
   
+
+test_that('Very slight exceeding of SILT+CLAY+SAND are accepted but no more than 100.0005',{
+  expect_equal(
+    sptf_bd140(
+      A_SOM_LOI = c(1,1,1,1),
+      A_CLAY_MI = c(33,75,1,1),
+      A_SAND_MI = c(34,24,98,1),
+      A_SILT_MI = c(33,1,1,98)
+    ),
+    expected = c(1102.4782, 1286.4414, 1072.0376,  918.9249),
+    tolerance = 0.01
+  )
+  # function if slighly exceeding rowsums 100
+  expect_equal(
+    sptf_bd140(
+      A_SOM_LOI = c(1,1,1,1),
+      A_CLAY_MI = c(33.0005,75,1,1),
+      A_SAND_MI = c(34,24.0005,98,1),
+      A_SILT_MI = c(33,1,1.0005,98)
+    ),
+    expected = c(1102.4782, 1286.4414, 1072.0376,  918.9249),
+    tolerance = 0.01
+  )
+  # test for error when just exceeding the checkmate tolerance
+  expect_error(
+    sptf_bd140(
+      A_SOM_LOI = c(1,1,1,1),
+      A_CLAY_MI = c(33.00051,75,1,1),
+      A_SAND_MI = c(34,24.00051,98,1),
+      A_SILT_MI = c(33,1,1.00051,98)
+    )
+    )
+})
+
+  


### PR DESCRIPTION
Conditions for checkmate for texture (e.g. sand + clay + silt <= 100) is corrected.
